### PR TITLE
Dont run container as root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.13 AS builder
 ARG CYBERDROP_DL_VERSION
 ARG TARGETARCH
 ARG FIXUID_VERSION="0.6.0"
+ARG GOTTY_VERSION="1.5.0"
 
 WORKDIR /cyberdrop-dl
 
@@ -11,14 +12,15 @@ RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir cyberdrop-dl-patched${CYBERDROP_DL_VERSION:+\=\=${CYBERDROP_DL_VERSION}}
 
 # Install and configure fixuid and switch to APP_USER
-RUN set -ex && case ${TARGETARCH:-amd64} in \
-        "arm64") curl -SsL https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-arm64.tar.gz | tar -C /usr/local/bin -xzf - ;; \
-        "amd64") curl -SsL https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - ;; \
-        *) echo "Dockerfile does not support this platform"; exit 1 ;; \
-    esac && \
+RUN set -ex && \
+    curl -SsL https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-${TARGETARCH:-amd64}.tar.gz | tar -C /usr/local/bin -xzf - && \
     chown root:root /usr/local/bin/fixuid && \
     chmod 4755 /usr/local/bin/fixuid
 
+RUN set -ex && \
+    curl -SsL https://github.com/sorenisanerd/gotty/releases/download/v${GOTTY_VERSION}/gotty_v${GOTTY_VERSION}_linux_${TARGETARCH:-amd64}.tar.gz | tar -C /usr/local/bin -xzf - && \
+    chown root:root /usr/local/bin/gotty && \
+    chmod 755 /usr/local/bin/gotty
 
 FROM python:3.13-slim
 
@@ -27,9 +29,15 @@ ARG APP_USER="abc"
 ENV TERM=xterm-256color
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING=UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
 
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
+
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends tmux && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN adduser --shell /bin/bash $APP_USER && \
     mkdir -p /etc/fixuid && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /cyberdrop-dl
 
 ENV PYTHONUNBUFFERED=1
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir cyberdrop-dl-patched==${CYBERDROP_DL_VERSION}
+    && pip install --no-cache-dir cyberdrop-dl-patched${CYBERDROP_DL_VERSION:+\=\=${CYBERDROP_DL_VERSION}}
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM python:3.13-slim AS builder
+FROM python:3.13 AS builder
 
 ARG CYBERDROP_DL_VERSION
+ARG TARGETARCH
+ARG FIXUID_VERSION="0.6.0"
 
 WORKDIR /cyberdrop-dl
 
@@ -8,18 +10,36 @@ ENV PYTHONUNBUFFERED=1
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir cyberdrop-dl-patched${CYBERDROP_DL_VERSION:+\=\=${CYBERDROP_DL_VERSION}}
 
-COPY . .
+# Install and configure fixuid and switch to APP_USER
+RUN set -ex && case ${TARGETARCH:-amd64} in \
+        "arm64") curl -SsL https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-arm64.tar.gz | tar -C /usr/local/bin -xzf - ;; \
+        "amd64") curl -SsL https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - ;; \
+        *) echo "Dockerfile does not support this platform"; exit 1 ;; \
+    esac && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid
+
 
 FROM python:3.13-slim
+
+ARG APP_USER="abc"
 
 ENV TERM=xterm-256color
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING=UTF-8
 
-WORKDIR /cyberdrop-dl
-
-COPY --from=builder /cyberdrop-dl /cyberdrop-dl
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
+
+RUN adduser --shell /bin/bash $APP_USER && \
+    mkdir -p /etc/fixuid && \
+    printf "user: ${APP_USER}\ngroup: ${APP_USER}\n" > /etc/fixuid/config.yml
+USER "${APP_USER}:${APP_USER}"
+
+WORKDIR /cyberdrop-dl
+COPY --from=builder /cyberdrop-dl /cyberdrop-dl
+
+ADD --chmod=755 entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]
 
 CMD ["cyberdrop-dl"]

--- a/README.md
+++ b/README.md
@@ -65,3 +65,10 @@ services:
     # You can override the default command by changing the following line
     command: ["cyberdrop-dl"]
 ```
+
+## Running as a different user
+
+In situations where you need the daemon to be run as a different user, specify a user/group in your `docker run` or `docker-compose.yml` file to run as a different user. [fixuid](https://github.com/boxboat/fixuid) will handle it at runtime.
+
+- In `docker run` commands, you can specify the user like this: `--user 1000:1000`
+- In `docker-compose.yml` files, you can specify the user like this: `user: ${FIXUID:-1000}:${FIXGID:-1000}`

--- a/README.md
+++ b/README.md
@@ -72,3 +72,13 @@ In situations where you need the daemon to be run as a different user, specify a
 
 - In `docker run` commands, you can specify the user like this: `--user 1000:1000`
 - In `docker-compose.yml` files, you can specify the user like this: `user: ${FIXUID:-1000}:${FIXGID:-1000}`
+
+## Web TTY
+
+Support for headless operation with UI via the web is available via [gotty](https://github.com/sorenisanerd/gotty). Configuration via env, most common options:
+
+- `GOTTY=true` to enable
+- `GOTTY_PORT=6969`
+- `GOTTY_CREDENTIAL=user:pass`
+
+See [gotty docs](https://github.com/sorenisanerd/gotty/#options) for additional options, including tls.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
-# adjust permissions if needed
-exec fixuid -q "$@"
+# adjust permissions with fixuid if needed
+if [[ "$GOTTY" == "true" ]]; then
+	# run app in background
+	fixuid -q tmux new -d -s gotty "$@"
+
+	# WebTTY connects to tmux
+	gotty tmux new -A -s gotty &
+	# if no tmux channel then cleanup
+	tmux wait gotty && kill $!
+else
+	exec fixuid -q "$@"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+# adjust permissions if needed
+exec fixuid -q "$@"


### PR DESCRIPTION
Allow the user to configure the uid:gid via standard docker mechanisms.

Included other trivial build fixes, feel free to cherry pick out if you disagree:
* Standard Dockerfile name, with capital
* Don't require user to specify CYBERDROP_DL_VERSION build arg, assume latest